### PR TITLE
handle the overflow of text in the rating description

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mind-gym/elements",
     "summary": "A collection of Elm UI elements",
     "license": "BSD-3-Clause",
-    "version": "4.7.2",
+    "version": "4.7.3",
     "exposed-modules": [
         "MG.Colours",
         "MG.Viewport",

--- a/src/MG/Input.elm
+++ b/src/MG/Input.elm
@@ -745,7 +745,7 @@ ratingScale { options, viewport, onSelect, selected } =
                         none
 
                 else
-                    el
+                    paragraph
                         (Typography.noteL.medium viewport
                             ++ [ Font.light
                                , width fill
@@ -766,7 +766,7 @@ ratingScale { options, viewport, onSelect, selected } =
                                , padding 24
                                ]
                         )
-                    <|
-                        text <|
+                        [ text <|
                             Maybe.withDefault "" selectedOption.description
+                        ]
         ]


### PR DESCRIPTION
<img width="955" alt="Screenshot 2024-08-30 at 12 11 06" src="https://github.com/user-attachments/assets/02fa8a99-cad7-4031-a8f9-4c4c9e7ffbc6">
