### PR TITLE
EDD-649: Added hamburger icon

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mind-gym/elements",
     "summary": "A collection of Elm UI elements",
     "license": "BSD-3-Clause",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "exposed-modules": [
         "MG.Colours",
         "MG.Viewport",

--- a/src/MG/Icons.elm
+++ b/src/MG/Icons.elm
@@ -1,11 +1,11 @@
-module MG.Icons exposing (show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse)
+module MG.Icons exposing (show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger)
 
 {-|
 
 
 # Icons
 
-@docs show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse
+@docs show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger
 
 -}
 
@@ -109,3 +109,9 @@ collapse size =
         [ chevronDown <| size // 2
         , chevronUp <| size // 2
         ]
+
+
+{-| -}
+hamburger : Int -> Element msg
+hamburger =
+    icon Icons.visibility


### PR DESCRIPTION
Hamburger icon is added as it is needed for changing expand/collapse all button on BCAT

![image](https://github.com/user-attachments/assets/b466d239-ded9-4f36-903f-81104b2d6da3)
