### PR TITLE
EDD-545: Added download icon

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mind-gym/elements",
     "summary": "A collection of Elm UI elements",
     "license": "BSD-3-Clause",
-    "version": "5.1.1",
+    "version": "5.2.0",
     "exposed-modules": [
         "MG.Colours",
         "MG.Viewport",

--- a/src/MG/Icons.elm
+++ b/src/MG/Icons.elm
@@ -1,11 +1,11 @@
-module MG.Icons exposing (show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger)
+module MG.Icons exposing (show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger, download)
 
 {-|
 
 
 # Icons
 
-@docs show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger
+@docs show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger, download
 
 -}
 
@@ -115,3 +115,9 @@ collapse size =
 hamburger : Int -> Element msg
 hamburger =
     icon Icons.menu
+
+
+{-| -}
+download : Int -> Element msg
+download =
+    icon Icons.download


### PR DESCRIPTION
Download icon is added as it is needed for adding download button to report on BCAT[
EDD-545](https://themindgym.atlassian.net/browse/EDD-545)


![image](https://github.com/user-attachments/assets/ac75f92c-dd4b-42f3-bb56-ecf4c6ebc57c)

