### PR TITLE
EDD-744: Icons added for new designs

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mind-gym/elements",
     "summary": "A collection of Elm UI elements",
     "license": "BSD-3-Clause",
-    "version": "5.2.0",
+    "version": "5.3.0",
     "exposed-modules": [
         "MG.Colours",
         "MG.Viewport",

--- a/src/MG/Icons.elm
+++ b/src/MG/Icons.elm
@@ -1,11 +1,11 @@
-module MG.Icons exposing (show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger, download)
+module MG.Icons exposing (show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger, download, search, assignment, diamond, arrowCircleRight, arrowCircleLeft)
 
 {-|
 
 
 # Icons
 
-@docs show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger, download
+@docs show, hide, rightArrow, leftArrow, warning, success, logOut, cross, plus, chevronDown, chevronUp, chevronRight, expand, collapse, hamburger, download, search, assignment, diamond, arrowCircleRight, arrowCircleLeft
 
 -}
 
@@ -121,3 +121,33 @@ hamburger =
 download : Int -> Element msg
 download =
     icon Icons.download
+
+
+{-| -}
+search : Int -> Element msg
+search =
+    icon Icons.search
+
+
+{-| -}
+assignment : Int -> Element msg
+assignment =
+    icon Icons.assignment
+
+
+{-| -}
+diamond : Int -> Element msg
+diamond =
+    icon Icons.diamond
+
+
+{-| -}
+arrowCircleRight : Int -> Element msg
+arrowCircleRight =
+    icon Icons.arrow_circle_right
+
+
+{-| -}
+arrowCircleLeft : Int -> Element msg
+arrowCircleLeft =
+    icon Icons.arrow_circle_left


### PR DESCRIPTION
The following icons have been added to this package:

arrowCircleLeft -> 
![image](https://github.com/user-attachments/assets/49051308-7065-4f07-ab69-b2317b41a298)

arrowCircleRIght ->
![image](https://github.com/user-attachments/assets/9c7cca03-1627-4399-be3f-c0ee9fe12712)

search -> 
![image](https://github.com/user-attachments/assets/f9c0d691-731c-458a-b80c-752ff7ee0fb1)

assignment ->
![image](https://github.com/user-attachments/assets/0ca40379-caef-484d-b999-ee927ac2fcad)

diamond ->
![image](https://github.com/user-attachments/assets/a093d279-adf7-4c9e-b3fa-c0e72dc3aa9b)

